### PR TITLE
Update yarn to 1.22.22

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "yarn" %}
-{% set version = "1.22.19" %}
+{% set version = "1.22.22" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://registry.npmjs.org/{{ name }}/-/{{ name }}-{{ version }}.tgz
-  sha1: 4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447
+  sha1: ac34549e6aa8e7ead463a7407e1c7390f61a6610
 
 build:
   number: 0


### PR DESCRIPTION
yarn 1.22.22 

**Destination channel:** defaults

### Links

- [PKG-9544](https://anaconda.atlassian.net/browse/PKG-9544)
- [Upstream repository](https://github.com/yarnpkg/yarn)
- [Upstream changelog/diff](https://github.com/yarnpkg/yarn/compare/v1.22.19...v1.22.22)


### Explanation of changes:
- Updated yarn from 1.22.19 to 1.22.22 (latest stable release)



[PKG-9544]: https://anaconda.atlassian.net/browse/PKG-9544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ